### PR TITLE
Fix indentation of supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ Currently implemented algorithms:
 * English
 * English (Porter)
 * Romance stemmers:
- * French
- * Spanish
- * Portuguese
- * Italian
- * Romanian
+  * French
+  * Spanish
+  * Portuguese
+  * Italian
+  * Romanian
 * Germanic stemmers:
- * German
- * Dutch
+  * German
+  * Dutch
 * Scandinavian stemmers:
- * Swedish
- * Norwegian (Bokmål)
- * Danish
+  * Swedish
+  * Norwegian (Bokmål)
+  * Danish
 * Russian
 * Finnish
 * Greek


### PR DESCRIPTION
Hi! I was reading the library's README and I spot a little problem with indentation of supported languages. Here is the fix 😉 