### PR TITLE
Change to ArrayType(StringType)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# Spark Stemming
+# Spark Stemming Fork
 
-[![Build Status](https://travis-ci.org/master/spark-stemming.svg?branch=master)](https://travis-ci.org/master/spark-stemming)
+A fork to update to Spark 2.2 and operate on Array(StringType) input rather than only string input.  That is, this fork fixes:
+
+```
+java.lang.IllegalArgumentException: requirement failed: Input type must be string type but got ArrayType(StringType,true)
+```
+
+Maven and SBT probably won't work as described in the README below but you should be able to compile this locally.
+
+== original README ==
 
 [Snowball](http://snowballstem.org/) is a small string processing language
 designed for creating stemming algorithms for use in Information Retrieval.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
-# Spark Stemming Fork
+# Spark Stemming
 
-A fork to update to Spark 2.2 and operate on Array(StringType) input rather than only string input.  That is, this fork fixes:
-
-```
-java.lang.IllegalArgumentException: requirement failed: Input type must be string type but got ArrayType(StringType,true)
-```
-
-Maven and SBT probably won't work as described in the README below but you should be able to compile this locally.
-
-== original README ==
+[![Build Status](https://travis-ci.org/master/spark-stemming.svg?branch=master)](https://travis-ci.org/master/spark-stemming)
 
 [Snowball](http://snowballstem.org/) is a small string processing language
 designed for creating stemming algorithms for use in Information Retrieval.

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "com.github.master"
 
 spName := "master/spark-stemming"
 
-version := "0.1.2"
+version := "0.2.0"
 
-sparkVersion := "1.6.1"
+sparkVersion := "2.2.0"
 
 scalaVersion := "2.10.6"
 

--- a/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
+++ b/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
@@ -2,12 +2,12 @@ package org.apache.spark.mllib.feature
 
 import org.tartarus.snowball.SnowballStemmer
 
-import org.apache.spark.sql.types.{DataType, StringType}
+import org.apache.spark.sql.types.{DataType, StringType, ArrayType}
 import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.UnaryTransformer
 
-class Stemmer(override val uid: String) extends UnaryTransformer[String, String, Stemmer] {
+class Stemmer(override val uid: String) extends UnaryTransformer[Seq[String], Seq[String], Stemmer] {
 
   def this() = this(Identifiable.randomUID("stemmer"))
 
@@ -17,23 +17,22 @@ class Stemmer(override val uid: String) extends UnaryTransformer[String, String,
 
   setDefault(language -> "English")
 
-  override protected def createTransformFunc: String => String = {
+  override protected def createTransformFunc: Seq[String] => Seq[String] = { strArray =>
     val stemClass = Class.forName("org.tartarus.snowball.ext." + $(language).toLowerCase + "Stemmer")
     val stemmer = stemClass.newInstance.asInstanceOf[SnowballStemmer]
-    originStr => try {
+    strArray.map(originStr => {
       stemmer.setCurrent(originStr)
       stemmer.stem()
       stemmer.getCurrent
-    } catch {
-      case e: Exception => originStr
-    }
+    })
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {
-    require(inputType == StringType, s"Input type must be string type but got $inputType.")
+    require(inputType.sameType(ArrayType(StringType)),
+            s"Input type must be ArrayType(StringType) but got $inputType.")
   }
 
-  override protected def outputDataType: DataType = StringType
+  override protected def outputDataType: DataType = new ArrayType(StringType, false)
 
   override def copy(extra: ParamMap): Stemmer = defaultCopy(extra)
 }

--- a/src/test/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/StemmerSuite.scala
+++ b/src/test/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/StemmerSuite.scala
@@ -5,11 +5,8 @@ import org.scalatest.FunSuite
 class StemmerSuite extends FunSuite with LocalSparkContext {
   test("Stemming of English words") {
     val data = sqlContext.createDataFrame(Seq(
-      ("All", 1),
-      ("mimsy", 2),
-      ("were", 3),
-      ("the", 4),
-      ("borogoves", 5)
+      (Array("All", "mimsy"), 1),
+      (Array("were", "the", "borogroves"), 2)
     )).toDF("word", "id")
 
     val stemmed = new Stemmer()
@@ -18,11 +15,8 @@ class StemmerSuite extends FunSuite with LocalSparkContext {
       .transform(data)
 
     val expected = sqlContext.createDataFrame(Seq(
-      ("All", 1, "All"),
-      ("mimsy", 2, "mimsi"),
-      ("were", 3, "were"),
-      ("the", 4, "the"),
-      ("borogoves", 5, "borogov")
+      (Array("All", "mimsy"), 1, Array("All", "mimsi")),
+      (Array("were", "the", "borogroves"), 2, Array("were", "the", "borogrov"))
     )).toDF("word", "id", "stemmed")
 
     assert(stemmed.collect().deep == expected.collect().deep)
@@ -30,9 +24,9 @@ class StemmerSuite extends FunSuite with LocalSparkContext {
 
   test("Stemming of non-English words") {
     val data = sqlContext.createDataFrame(Seq(
-      ("övrigt", 1),
-      ("bildelar", 2),
-      ("biltillbehör", 3)
+      (Array("övrigt"), 1),
+      (Array("bildelar"), 2),
+      (Array("biltillbehör"), 3)
     )).toDF("word", "id")
 
     val stemmed = new Stemmer()
@@ -42,9 +36,9 @@ class StemmerSuite extends FunSuite with LocalSparkContext {
       .transform(data)
 
     val expected = sqlContext.createDataFrame(Seq(
-      ("övrigt", 1, "övr"),
-      ("bildelar", 2, "bildel"),
-      ("biltillbehör", 3, "biltillbehör")
+      (Array("övrigt"), 1, Array("övr")),
+      (Array("bildelar"), 2, Array("bildel")),
+      (Array("biltillbehör"), 3, Array("biltillbehör"))
     )).toDF("word", "id", "stemmed")
 
     assert(stemmed.collect().deep == expected.collect().deep)


### PR DESCRIPTION
If you pull this request, then the Stemmer will work with Seq[String], rather than merely String. This allows easy (easier?) use with Tokenizer and other transformers that work with arrays. I also updated to Spark 2.2 though it seemed to compile fine with the original Spark version as well.

This PR fixes an issue seen when using with Array(StringType): java.lang.IllegalArgumentException: requirement failed: Input type must be string type but got ArrayType(StringType,true). See e.g. the discussion at https://spark-packages.org/package/master/spark-stemming