### PR TITLE
Allow Stemmer to be written to and read from Pipeline

### DIFF
--- a/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
+++ b/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
@@ -36,3 +36,8 @@ class Stemmer(override val uid: String) extends UnaryTransformer[Seq[String], Se
 
   override def copy(extra: ParamMap): Stemmer = defaultCopy(extra)
 }
+
+object Stemmer extends DefaultParamsReadable[Stemmer] {
+
+  override def load(path: String): Stemmer = super.load(path)
+}

--- a/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
+++ b/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
@@ -3,7 +3,7 @@ package org.apache.spark.mllib.feature
 import org.tartarus.snowball.SnowballStemmer
 
 import org.apache.spark.sql.types.{DataType, StringType, ArrayType}
-import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.ml.util.{DefaultParamsReadable, DefaultParamsWritable, Identifiable}
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.UnaryTransformer
 

--- a/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
+++ b/src/main/scala/mllib/src/main/scala/org/apache/spark/mllib/feature/Stemmer.scala
@@ -7,7 +7,7 @@ import org.apache.spark.ml.util.Identifiable
 import org.apache.spark.ml.param.{Param, ParamMap}
 import org.apache.spark.ml.UnaryTransformer
 
-class Stemmer(override val uid: String) extends UnaryTransformer[Seq[String], Seq[String], Stemmer] {
+class Stemmer(override val uid: String) extends UnaryTransformer[Seq[String], Seq[String], Stemmer] with DefaultParamsWritable {
 
   def this() = this(Identifiable.randomUID("stemmer"))
 


### PR DESCRIPTION
Hey there, this pull request would allow for the Stemmer Transformer to be written out as part of a PipelineModel and also to be read in as a part of a PipelineModel.

For instance the current example fails at runtime:

```Scala
val tokenizer = new Tokenizer()
  .setInputCol("text")
  .setOutputCol("words")
val stemmer = new Stemmer()
.setInputCol(tokenizer.getOutputCol)
.setOutputCol("stems")
.setLanguage("English")
val hashingTF = new HashingTF()
  .setNumFeatures(1000)
  .setInputCol(stemmer.getOutputCol)
  .setOutputCol("features")
val lr = new LogisticRegression()
  .setMaxIter(10)
  .setRegParam(0.001)
val pipeline = new Pipeline()
  .setStages(Array(tokenizer, stemmer, hashingTF, lr))

val model = pipeline.fit(training)
model.write.overwrite().save("/tmp/spark-logistic-regression-model")

val sameModel = PipelineModel.read.load("/tmp/spark-logistic-regression-model")

sameModel.transform(test)
```
